### PR TITLE
Kafka 연동 및 outbox 패턴 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.3'
+
+	implementation 'org.springframework.kafka:spring-kafka'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,13 @@ dependencies {
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.3'
 
 	implementation 'org.springframework.kafka:spring-kafka'
+
+	testImplementation 'org.springframework.kafka:spring-kafka-test'
+	testImplementation 'org.springframework.kafka:spring-kafka'
+	testImplementation 'org.springframework:spring-test'
+
+	testImplementation 'org.testcontainers:junit-jupiter:1.19.0'
+	testImplementation 'org.testcontainers:kafka:1.19.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hhplus/concert/api/concert/application/ConcertService.java
+++ b/src/main/java/com/hhplus/concert/api/concert/application/ConcertService.java
@@ -7,6 +7,7 @@ import com.hhplus.concert.api.concert.domain.repository.ConcertRepository;
 import com.hhplus.concert.api.concert.domain.type.SeatStatus;
 import com.hhplus.concert.api.concert.domain.repository.ScheduleRepository;
 import com.hhplus.concert.api.concert.domain.repository.SeatRepository;
+import com.hhplus.concert.common.exception.list.CustomBadRequestException;
 import com.hhplus.concert.common.exception.list.CustomNotFoundException;
 import jakarta.persistence.EntityNotFoundException;
 import java.time.LocalDateTime;
@@ -101,10 +102,15 @@ public class ConcertService {
             log.info("[좌석 예약] 이미 예약된 좌석입니다.");
             throw new EntityNotFoundException("이미 예약된 좌석입니다.");
         }
+
+        if (seats.size() != seatIds.size()) {
+            log.info("[좌석 예약] 일부 좌석이 이미 예약된 상태입니다.");
+            throw new CustomBadRequestException(HttpStatus.BAD_REQUEST, "일부 좌석이 이미 예약된 상태입니다.");
+        }
+
         for (Seat seat : seats) {
             seat.updateSeatStatus(SeatStatus.IMPOSSIBLE, userId);
         }
-        seatRepository.saveAll(seats);
     }
 
 }

--- a/src/main/java/com/hhplus/concert/api/reservation/application/listener/ReservationEventListener.java
+++ b/src/main/java/com/hhplus/concert/api/reservation/application/listener/ReservationEventListener.java
@@ -18,6 +18,6 @@ public class ReservationEventListener {
     @Async
     @TransactionalEventListener(phase = AFTER_COMMIT)
     public void sendReservationInfo(ReservationEvent event) {
-        kafkaReservationProducer.sendReservationEvent(new ReservationEvent(event.getMessageId(), event.getSeatIds()));
+        kafkaReservationProducer.send(new ReservationEvent(event.getMessageId(), event.getSeatIds()));
     }
 }

--- a/src/main/java/com/hhplus/concert/api/reservation/application/listener/ReservationEventListener.java
+++ b/src/main/java/com/hhplus/concert/api/reservation/application/listener/ReservationEventListener.java
@@ -3,7 +3,7 @@ package com.hhplus.concert.api.reservation.application.listener;
 import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
 
 import com.hhplus.concert.api.reservation.domain.event.ReservationEvent;
-import com.hhplus.concert.api.reservation.infrastructure.DataPlatformMockApiClient;
+import com.hhplus.concert.api.reservation.infrastructure.kafka.KafkaReservationProducer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -13,11 +13,11 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 public class ReservationEventListener {
 
-    private final DataPlatformMockApiClient dataPlatformMockApiClient;
+    private final KafkaReservationProducer kafkaReservationProducer;
 
     @Async
     @TransactionalEventListener(phase = AFTER_COMMIT)
     public void sendReservationInfo(ReservationEvent event) {
-        dataPlatformMockApiClient.sendData(event.getReservation(), event.getReservationSeats());
+        kafkaReservationProducer.sendReservationEvent(new ReservationEvent(event.getMessageId(), event.getSeatIds()));
     }
 }

--- a/src/main/java/com/hhplus/concert/api/reservation/consumer/DataPlatformConsumer.java
+++ b/src/main/java/com/hhplus/concert/api/reservation/consumer/DataPlatformConsumer.java
@@ -4,6 +4,7 @@ import com.hhplus.concert.api.reservation.domain.event.ReservationEvent;
 import com.hhplus.concert.api.reservation.infrastructure.DataPlatformMockApiClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -13,7 +14,8 @@ public class DataPlatformConsumer {
     private final DataPlatformMockApiClient dataPlatformMockApiClient;
 
     @KafkaListener(topics = "reservation-topic", groupId = "reservation-group1")
-    public void handleEvent(ReservationEvent event) {
+    public void handleEvent(ReservationEvent event, Acknowledgment acknowledgment) {
         dataPlatformMockApiClient.sendData(event.getSeatIds());
+        acknowledgment.acknowledge();
     }
 }

--- a/src/main/java/com/hhplus/concert/api/reservation/consumer/DataPlatformConsumer.java
+++ b/src/main/java/com/hhplus/concert/api/reservation/consumer/DataPlatformConsumer.java
@@ -1,0 +1,19 @@
+package com.hhplus.concert.api.reservation.consumer;
+
+import com.hhplus.concert.api.reservation.domain.event.ReservationEvent;
+import com.hhplus.concert.api.reservation.infrastructure.DataPlatformMockApiClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DataPlatformConsumer {
+
+    private final DataPlatformMockApiClient dataPlatformMockApiClient;
+
+    @KafkaListener(topics = "reservation-topic", groupId = "reservation-group1")
+    public void handleEvent(ReservationEvent event) {
+        dataPlatformMockApiClient.sendData(event.getSeatIds());
+    }
+}

--- a/src/main/java/com/hhplus/concert/api/reservation/consumer/ReservationConsumer.java
+++ b/src/main/java/com/hhplus/concert/api/reservation/consumer/ReservationConsumer.java
@@ -1,0 +1,19 @@
+package com.hhplus.concert.api.reservation.consumer;
+
+import com.hhplus.concert.api.reservation.application.ReservationService;
+import com.hhplus.concert.api.reservation.domain.event.ReservationEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationConsumer {
+
+    private final ReservationService reservationService;
+
+    @KafkaListener(topics = "reservation-topic", groupId = "reservation-group")
+    public void handleEvent(ReservationEvent event) {
+        reservationService.reservationEventUpdate(event);
+    }
+}

--- a/src/main/java/com/hhplus/concert/api/reservation/domain/entity/ReservationCreatedEvent.java
+++ b/src/main/java/com/hhplus/concert/api/reservation/domain/entity/ReservationCreatedEvent.java
@@ -1,0 +1,37 @@
+package com.hhplus.concert.api.reservation.domain.entity;
+
+import com.hhplus.concert.api.reservation.domain.type.ReservationEventStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Builder
+@Table(name = "RESERVATION_CREATED_EVENT")
+public class ReservationCreatedEvent {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "RESERVATION_CREATED_EVENT_ID")
+    private Long reservationCreatedEventId;
+    @Column(name = "RESERVATION_ID")
+    private Long reservationId;
+    @Column(name = "RESERVATION_EVENT_STATUS")
+    private ReservationEventStatus reservationEventStatus;
+    @Column(name = "CREATED_AT")
+    private LocalDateTime createdAt;
+
+    public void updateStatus(ReservationEventStatus reservationEventStatus) {
+        this.reservationEventStatus = reservationEventStatus;
+    }
+}

--- a/src/main/java/com/hhplus/concert/api/reservation/domain/event/ReservationEvent.java
+++ b/src/main/java/com/hhplus/concert/api/reservation/domain/event/ReservationEvent.java
@@ -3,25 +3,23 @@ package com.hhplus.concert.api.reservation.domain.event;
 import com.hhplus.concert.api.reservation.domain.entity.Reservation;
 import com.hhplus.concert.api.reservation.domain.entity.ReservationSeat;
 import java.util.List;
-import org.springframework.context.ApplicationEvent;
 
-public class ReservationEvent extends ApplicationEvent {
+public class ReservationEvent {
 
-    private final Reservation reservation;
-    private final List<ReservationSeat> reservationSeats;
-
-    public ReservationEvent(Object source, Reservation reservation,
-        List<ReservationSeat> reservationSeats) {
-        super(source);
-        this.reservation = reservation;
-        this.reservationSeats = reservationSeats;
+    private Long messageId;
+    private List<Long> seatIds;
+    public ReservationEvent() {
+    }
+    public ReservationEvent(Long messageId, List<Long> seatIds) {
+        this.messageId = messageId;
+        this.seatIds = seatIds;
     }
 
-    public Reservation getReservation() {
-        return reservation;
+    public Long getMessageId() {
+        return messageId;
     }
 
-    public List<ReservationSeat> getReservationSeats() {
-        return reservationSeats;
+    public List<Long> getSeatIds() {
+        return seatIds;
     }
 }

--- a/src/main/java/com/hhplus/concert/api/reservation/domain/repository/ReservationCreatedEventRepository.java
+++ b/src/main/java/com/hhplus/concert/api/reservation/domain/repository/ReservationCreatedEventRepository.java
@@ -1,0 +1,10 @@
+package com.hhplus.concert.api.reservation.domain.repository;
+
+import com.hhplus.concert.api.reservation.domain.entity.ReservationCreatedEvent;
+import com.hhplus.concert.api.reservation.domain.type.ReservationEventStatus;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReservationCreatedEventRepository extends JpaRepository<ReservationCreatedEvent, Long> {
+    List<ReservationCreatedEvent> findAllByReservationEventStatus(ReservationEventStatus reservationEventStatus);
+}

--- a/src/main/java/com/hhplus/concert/api/reservation/domain/repository/ReservationCreatedEventRepository.java
+++ b/src/main/java/com/hhplus/concert/api/reservation/domain/repository/ReservationCreatedEventRepository.java
@@ -2,9 +2,10 @@ package com.hhplus.concert.api.reservation.domain.repository;
 
 import com.hhplus.concert.api.reservation.domain.entity.ReservationCreatedEvent;
 import com.hhplus.concert.api.reservation.domain.type.ReservationEventStatus;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReservationCreatedEventRepository extends JpaRepository<ReservationCreatedEvent, Long> {
-    List<ReservationCreatedEvent> findAllByReservationEventStatus(ReservationEventStatus reservationEventStatus);
+    List<ReservationCreatedEvent> findAllByReservationEventStatusAndCreatedAtBefore(ReservationEventStatus reservationEventStatus, LocalDateTime createdAt);
 }

--- a/src/main/java/com/hhplus/concert/api/reservation/domain/type/ReservationEventStatus.java
+++ b/src/main/java/com/hhplus/concert/api/reservation/domain/type/ReservationEventStatus.java
@@ -1,0 +1,23 @@
+package com.hhplus.concert.api.reservation.domain.type;
+
+import java.util.Arrays;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ReservationEventStatus {
+    INIT("1", "발송 대기"),
+    PUBLISHED("2", "발송 성공"),
+    FAILED("3", "발송 실패");
+
+    private String code;
+    private String desc;
+
+    public static ReservationEventStatus of(String code) {
+        return Arrays.stream(ReservationEventStatus.values())
+                     .filter(reservationStatus -> code.equals(reservationStatus.getCode()))
+                     .findFirst()
+                     .orElseThrow(() -> new IllegalArgumentException("[ReservationEventStatus] 존재하지 않는 코드입니다. { " + code + " }"));
+    }
+}

--- a/src/main/java/com/hhplus/concert/api/reservation/domain/type/converter/ReservationEventStatusConverter.java
+++ b/src/main/java/com/hhplus/concert/api/reservation/domain/type/converter/ReservationEventStatusConverter.java
@@ -1,0 +1,24 @@
+package com.hhplus.concert.api.reservation.domain.type.converter;
+
+import com.hhplus.concert.api.reservation.domain.type.ReservationEventStatus;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.EnumSet;
+import java.util.NoSuchElementException;
+
+@Converter(autoApply = true)
+public class ReservationEventStatusConverter implements AttributeConverter<ReservationEventStatus, String> {
+
+    @Override
+    public String convertToDatabaseColumn(ReservationEventStatus attribute) {
+        return attribute.getCode();
+    }
+
+    @Override
+    public ReservationEventStatus convertToEntityAttribute(String dbData) {
+        return EnumSet.allOf(ReservationEventStatus.class).stream()
+                      .filter(e -> e.getCode().equals(dbData))
+                      .findAny()
+                      .orElseThrow(NoSuchElementException::new);
+    }
+}

--- a/src/main/java/com/hhplus/concert/api/reservation/infrastructure/DataPlatformMockApiClient.java
+++ b/src/main/java/com/hhplus/concert/api/reservation/infrastructure/DataPlatformMockApiClient.java
@@ -1,7 +1,5 @@
 package com.hhplus.concert.api.reservation.infrastructure;
 
-import com.hhplus.concert.api.reservation.domain.entity.Reservation;
-import com.hhplus.concert.api.reservation.domain.entity.ReservationSeat;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -10,9 +8,9 @@ import org.springframework.stereotype.Component;
 @Component
 public class DataPlatformMockApiClient {
 
-    public void sendData(Reservation reservation, List<ReservationSeat> reservationSeats) {
+    public void sendData(List<Long> seatIds) {
         try {
-            log.info("[DataPlatform] : 좌석 예약 데이터 저장 성공 => " + reservationSeats.stream().map(ReservationSeat::getSeatId).toList());
+            log.info("[DataPlatform] : 좌석 예약 데이터 저장 성공 => " + seatIds);
         } catch (Exception e) {
             log.error("[DataPlatform] : 좌석 예약 데이터 저장 실패 => " + e.getMessage());
         }

--- a/src/main/java/com/hhplus/concert/api/reservation/infrastructure/DataPlatformMockApiClient.java
+++ b/src/main/java/com/hhplus/concert/api/reservation/infrastructure/DataPlatformMockApiClient.java
@@ -8,11 +8,13 @@ import org.springframework.stereotype.Component;
 @Component
 public class DataPlatformMockApiClient {
 
-    public void sendData(List<Long> seatIds) {
+    public boolean sendData(List<Long> seatIds) {
         try {
             log.info("[DataPlatform] : 좌석 예약 데이터 저장 성공 => " + seatIds);
+            return true;
         } catch (Exception e) {
             log.error("[DataPlatform] : 좌석 예약 데이터 저장 실패 => " + e.getMessage());
+            return false;
         }
     }
 }

--- a/src/main/java/com/hhplus/concert/api/reservation/infrastructure/SlackApiClient.java
+++ b/src/main/java/com/hhplus/concert/api/reservation/infrastructure/SlackApiClient.java
@@ -1,0 +1,17 @@
+package com.hhplus.concert.api.reservation.infrastructure;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class SlackApiClient {
+
+    public void sendMessageToDeveloper(Long reservationId) {
+        try {
+            log.info(String.format("[Slack] : 슬랙 메세지 전송 성공 => reservationId : %d 메세지 발행 실패", reservationId));
+        } catch (Exception e) {
+            log.error("[Slack] : 슬랙 메세지 전송 실패 => " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/hhplus/concert/api/reservation/infrastructure/kafka/KafkaReservationProducer.java
+++ b/src/main/java/com/hhplus/concert/api/reservation/infrastructure/kafka/KafkaReservationProducer.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 public class KafkaReservationProducer {
     private final KafkaTemplate<String, ReservationEvent> kafkaTemplate;
 
-    public void sendReservationEvent(ReservationEvent event) {
+    public void send(ReservationEvent event) {
         kafkaTemplate.send("reservation-topic", "reservation", event);
     }
 }

--- a/src/main/java/com/hhplus/concert/api/reservation/infrastructure/kafka/KafkaReservationProducer.java
+++ b/src/main/java/com/hhplus/concert/api/reservation/infrastructure/kafka/KafkaReservationProducer.java
@@ -1,0 +1,16 @@
+package com.hhplus.concert.api.reservation.infrastructure.kafka;
+
+import com.hhplus.concert.api.reservation.domain.event.ReservationEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class KafkaReservationProducer {
+    private final KafkaTemplate<String, ReservationEvent> kafkaTemplate;
+
+    public void sendReservationEvent(ReservationEvent event) {
+        kafkaTemplate.send("reservation-topic", "reservation", event);
+    }
+}

--- a/src/main/java/com/hhplus/concert/api/reservation/scheduler/ReservationScheduler.java
+++ b/src/main/java/com/hhplus/concert/api/reservation/scheduler/ReservationScheduler.java
@@ -15,4 +15,9 @@ public class ReservationScheduler {
     public void processReservationExpired() {
         reservationService.reservationExpiredCheck();
     }
+
+    @Scheduled(fixedRate = 5000)
+    public void processKafkaPublish() {
+        reservationService.getReservationCreatedEvent();
+    }
 }

--- a/src/main/java/com/hhplus/concert/config/KafkaConfig.java
+++ b/src/main/java/com/hhplus/concert/config/KafkaConfig.java
@@ -45,7 +45,6 @@ public class KafkaConfig {
         config.put(ConsumerConfig.GROUP_ID_CONFIG, "reservation-group");
         config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
-        config.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
         return new DefaultKafkaConsumerFactory<>(config, new StringDeserializer(),
                                                  new ErrorHandlingDeserializer<>(new JsonDeserializer<>(ReservationEvent.class)));
     }

--- a/src/main/java/com/hhplus/concert/config/KafkaConfig.java
+++ b/src/main/java/com/hhplus/concert/config/KafkaConfig.java
@@ -1,0 +1,62 @@
+package com.hhplus.concert.config;
+
+import com.hhplus.concert.api.reservation.domain.event.ReservationEvent;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@Configuration
+@EnableKafka
+public class KafkaConfig {
+    @Bean
+    public ProducerFactory<String, ReservationEvent> producerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    @Bean
+    public KafkaTemplate<String, ReservationEvent> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    @Bean
+    public ConsumerFactory<String, ReservationEvent> consumerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        config.put(ConsumerConfig.GROUP_ID_CONFIG, "reservation-group");
+        config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        config.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+        return new DefaultKafkaConsumerFactory<>(config, new StringDeserializer(),
+                                                 new ErrorHandlingDeserializer<>(new JsonDeserializer<>(ReservationEvent.class)));
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, ReservationEvent> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, ReservationEvent> factory =
+            new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
+        return factory;
+    }
+
+}

--- a/src/main/resources/docker-compose.yml
+++ b/src/main/resources/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3'
+services:
+  zookeeper:
+    image: 'confluentinc/cp-zookeeper:latest'
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - '2181:2181'
+
+  kafka:
+    image: 'confluentinc/cp-kafka:latest'
+    depends_on:
+      - zookeeper
+    ports:
+      - '9092:9092'
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1

--- a/src/test/java/com/hhplus/concert/integration/kafka/DataPlatformConsumerIntegrationTest.java
+++ b/src/test/java/com/hhplus/concert/integration/kafka/DataPlatformConsumerIntegrationTest.java
@@ -1,0 +1,39 @@
+package com.hhplus.concert.integration.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.hhplus.concert.api.reservation.domain.event.ReservationEvent;
+import com.hhplus.concert.api.reservation.infrastructure.DataPlatformMockApiClient;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.KafkaTemplate;
+
+@SpringBootTest
+public class DataPlatformConsumerIntegrationTest {
+
+    @Autowired
+    private KafkaTemplate<String, ReservationEvent> kafkaTemplate;
+
+    @Autowired
+    private DataPlatformMockApiClient dataPlatformMockApiClient;
+
+    @DisplayName("kafka 이벤트 메시지 발행 및 응답 테스트")
+    @Test
+    public void handle_event_test() throws InterruptedException {
+        // given
+        Long messageId = 1L;
+        List<Long> seatIds = Arrays.asList(1L, 2L, 3L);
+        ReservationEvent event = new ReservationEvent(messageId, seatIds);
+
+        // when
+        kafkaTemplate.send("reservation-topic", "reservation", event);
+
+        // then
+        Thread.sleep(2000);
+        assertEquals(dataPlatformMockApiClient.sendData(seatIds), true);
+    }
+}

--- a/src/test/java/com/hhplus/concert/integration/kafka/EmbeddedKafkaIntegrationTest.java
+++ b/src/test/java/com/hhplus/concert/integration/kafka/EmbeddedKafkaIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.hhplus.concert.integration.kafka;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.hhplus.concert.api.reservation.domain.event.ReservationEvent;
 import com.hhplus.concert.api.reservation.infrastructure.DataPlatformMockApiClient;
@@ -10,16 +11,24 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.context.EmbeddedKafka;
 
 @SpringBootTest
-public class DataPlatformConsumerIntegrationTest {
+@EmbeddedKafka(partitions = 1, topics = { "reservation-topic" }, brokerProperties = { "listeners=PLAINTEXT://localhost:9092", "port=9092" })
+public class EmbeddedKafkaIntegrationTest {
 
     @Autowired
     private KafkaTemplate<String, ReservationEvent> kafkaTemplate;
-
     @Autowired
     private DataPlatformMockApiClient dataPlatformMockApiClient;
+    private ReservationEvent reservationEvent;
+
+    @KafkaListener(topics = "reservation-test-topic", groupId = "test-group")
+    public void listen(ReservationEvent event) {
+        this.reservationEvent = event;
+    }
 
     @DisplayName("kafka 이벤트 메시지 발행 및 응답 테스트")
     @Test
@@ -30,10 +39,13 @@ public class DataPlatformConsumerIntegrationTest {
         ReservationEvent event = new ReservationEvent(messageId, seatIds);
 
         // when
-        kafkaTemplate.send("reservation-topic", "reservation", event);
+        kafkaTemplate.send("reservation-test-topic", "reservation", event);
 
         // then
         Thread.sleep(2000);
         assertEquals(dataPlatformMockApiClient.sendData(seatIds), true);
+        assertNotNull(reservationEvent);
+        assertEquals(1L, reservationEvent.getMessageId());
+        assertEquals(Arrays.asList(1L, 2L, 3L), reservationEvent.getSeatIds());
     }
 }

--- a/src/test/java/com/hhplus/concert/integration/kafka/KafkaContainerIntegrationTest.java
+++ b/src/test/java/com/hhplus/concert/integration/kafka/KafkaContainerIntegrationTest.java
@@ -1,0 +1,76 @@
+package com.hhplus.concert.integration.kafka;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hhplus.concert.api.reservation.domain.event.ReservationEvent;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest
+@DirtiesContext
+@EnableKafka
+public class KafkaContainerIntegrationTest {
+
+    private static KafkaContainer kafkaContainer;
+    @Autowired
+    private KafkaTemplate<String, ReservationEvent> kafkaTemplate;
+
+    private final CountDownLatch latch = new CountDownLatch(1);
+    private ReservationEvent reservationEvent;
+
+    @BeforeAll
+    public static void setUp() {
+        kafkaContainer = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:latest"));
+        kafkaContainer.start();
+        System.setProperty("spring.kafka.bootstrap-servers", kafkaContainer.getBootstrapServers());
+    }
+
+    @AfterAll
+    public static void containerDown() {
+        if (kafkaContainer != null) {
+            kafkaContainer.stop();
+        }
+    }
+
+    @KafkaListener(topics = "reservation-test-topic", groupId = "reservation-group")
+    public void listen(ReservationEvent event) {
+        this.reservationEvent = event;
+        latch.countDown();
+    }
+
+    @DisplayName("Kafka 이벤트 메시지 발행 및 응답 테스트")
+    @Test
+    public void handle_event_test() throws InterruptedException {
+        // given
+        Long messageId = 1L;
+        List<Long> seatIds = Arrays.asList(1L, 2L, 3L);
+        ReservationEvent event = new ReservationEvent(messageId, seatIds);
+
+        // when
+        kafkaTemplate.send("reservation-test-topic", "reservation", event);
+
+        // then
+        boolean messageReceived = latch.await(10, TimeUnit.SECONDS);
+        assertTrue(messageReceived);
+        assertNotNull(reservationEvent);
+        assertEquals(1L, reservationEvent.getMessageId());
+        assertEquals(Arrays.asList(1L, 2L, 3L), reservationEvent.getSeatIds());
+    }
+}

--- a/src/test/java/com/hhplus/concert/integration/kafka/SchedulerIntegrationTest.java
+++ b/src/test/java/com/hhplus/concert/integration/kafka/SchedulerIntegrationTest.java
@@ -1,0 +1,50 @@
+package com.hhplus.concert.integration.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hhplus.concert.api.reservation.application.ReservationService;
+import com.hhplus.concert.api.reservation.domain.entity.ReservationCreatedEvent;
+import com.hhplus.concert.api.reservation.domain.repository.ReservationCreatedEventRepository;
+import com.hhplus.concert.api.reservation.domain.type.ReservationEventStatus;
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+
+@SpringBootTest
+@Transactional
+@Rollback
+public class SchedulerIntegrationTest {
+
+    @Autowired
+    private ReservationService reservationService;
+
+    @Autowired
+    private ReservationCreatedEventRepository reservationCreatedEventRepository;
+    private Long messageId;
+
+    @BeforeEach
+    public void setUp() {
+        ReservationCreatedEvent event = new ReservationCreatedEvent(null,
+                                                                    1L,
+                                                                    ReservationEventStatus.INIT,
+                                                                    LocalDateTime.now().minusMinutes(10));
+        this.messageId = reservationCreatedEventRepository.save(event).getReservationCreatedEventId();
+    }
+
+    @DisplayName("outbox 스케줄러 테스트")
+    @Test
+    public void outbox_scheduler_test() {
+        // given
+        // when
+        reservationService.getReservationCreatedEvent();
+        // Then
+        Optional<ReservationCreatedEvent> testEvent = reservationCreatedEventRepository.findById(messageId);
+        assertThat(testEvent.get().getReservationEventStatus()).isEqualTo(ReservationEventStatus.FAILED);
+    }
+}


### PR DESCRIPTION
### 수정사항
- kafka 연동
- Mock Api Client 추가
- kafka 메시지 발행 및 소비 추가
- outbox 패턴 추가
- EmbeddedKafka, kafka 테스트컨테이너, outbox, scheduler 테스트 추가

### 리뷰포인트
- 9af0cf5c1112dea5083c9c2b03ccd416e9ec2fb5 kafka EmbeddedKafka, 테스트컨테이너 2가지 방식의 테스트 및 outbox 패턴(outbox, scheduler) 테스트
- e3d4f725228f97a630cc71748fb11e6fef5bf12a kafka docker-compose 및 config 추가
- 35b5b3855117a4b73636388de46f7be6108c60bd kafka 이벤트 발행 및 소비 // outbox 패턴 추가

### 추가 문의사항
- EmbeddedKafka 테스트를 작성하고 테스트 컨테이너 방식도 추가로 작업하였습니다. 테스트 컨테이너 방식은 local에 테스트 컨테이너가 뜨는 것을 확인했는데 kafka가 docker에 띄워져 있지 않으면 연동이 되지 않습니다. 테스트 컨테이너를 띄워서 하는 테스트이니 EmbeddedKafka 방식과 마찬가지로 kafka 서버를 띄워놓지 않아도 된다고 생각하는데 이 생각이 잘못된 것인지 아니면 테스트 소스가 문제인지 그렇다면 어떤 부분이 문제인지 궁금합니다.
- outbox 패턴을 잘 이해하고 적용하였는지 궁금합니다.